### PR TITLE
Add support for returning a transaction result

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jvalue/node-dry-pg",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
It is currently hard to pass a result from the transaction function to the outside. Therefore I have added support for it. The returned value of the transaction function is now returned to the caller of `transaction()`.