### PR TITLE
Rename PostgresRepository into PostgresClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
-export { PostgresRepository } from './postgresRepository'
+import { PostgresClient } from './postgresClient'
+
+// Export `PostgresClient` also under its old name `PostgresRepository`, so users can update gradually
+export { PostgresClient, PostgresClient as PostgresRepository }

--- a/src/postgresClient.ts
+++ b/src/postgresClient.ts
@@ -2,7 +2,7 @@ import { Pool, PoolConfig, QueryResult, ClientBase } from 'pg'
 
 import { sleep, stringifiers } from '@jvalue/node-dry-basics'
 
-export class PostgresRepository {
+export class PostgresClient {
   private readonly connectionPool: Pool
 
   constructor (poolConfig?: PoolConfig) {


### PR DESCRIPTION
This fixes #5 by renaming `PostgresRepository` into `PostgresClient`. The `PostgresClient` is still exported under its old name  `PostgresRepository` so this is not a breaking change and we can update all usages gradually.

I am marking this as a draft for now, as we might come up with a better name.